### PR TITLE
Feat/28 report auto layout

### DIFF
--- a/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
@@ -16,8 +16,7 @@ final class BDSNavigationBar: UIView {
     
     public enum Metric {
         static let navigationHeight: CGFloat = 44
-        static let titleTop: CGFloat = 19
-        static let buttonTop: CGFloat = 6
+        static let titleTop: CGFloat = 13
         static let buttonLeading: CGFloat = 4
         static let buttonTrailing: CGFloat = 7
         static let buttonSize: CGFloat = 44
@@ -100,9 +99,8 @@ final class BDSNavigationBar: UIView {
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview()
+            make.top.equalToSuperview().inset(Metric.titleTop)
             make.centerX.equalToSuperview()
-            
         }
         
         closeButton.snp.makeConstraints { make in

--- a/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
@@ -72,6 +72,13 @@ final class BDSNavigationBar: UIView {
         setupBackButton(isHidden: isHidden)
     }
     
+    convenience init(_ viewController: UIViewController,
+                     view: PageView,
+                     isHidden: Bool, mediaType: MediaType) {
+        self.init(viewController, view: view, isHidden: isHidden)
+        setupWriteTitle(mediaType: mediaType)
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -115,5 +122,9 @@ final class BDSNavigationBar: UIView {
     private func setupBackButton(isHidden: Bool) {
         backButton.isHidden = isHidden
         closeButton.isHidden = !backButton.isHidden
+    }
+    
+    private func setupWriteTitle(mediaType: MediaType) {
+        titleLabel.text = "\(mediaType)"
     }
 }

--- a/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Global/DesignSystem/UIComponet/BDSNavigationBar.swift
@@ -15,7 +15,7 @@ final class BDSNavigationBar: UIView {
     // MARK: - Metric Enum
     
     public enum Metric {
-        static let navigationHeight: CGFloat = 44
+        static let navigationHeight: CGFloat = UIScreen.main.hasNotch ? 44 : 50
         static let titleTop: CGFloat = 13
         static let buttonLeading: CGFloat = 4
         static let buttonTrailing: CGFloat = 7

--- a/Beforeget-iOS/Beforeget-iOS/Resource/Support/SceneDelegate.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Resource/Support/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: scene)
         self.window?.backgroundColor = .white
         
-        self.window?.rootViewController = UINavigationController(rootViewController: MainViewController())
+        self.window?.rootViewController = ReportViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
         self.window?.makeKeyAndVisible()
     }
 

--- a/Beforeget-iOS/Beforeget-iOS/Resource/Support/SceneDelegate.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Resource/Support/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: scene)
         self.window?.backgroundColor = .white
         
-        self.window?.rootViewController = ReportViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        self.window?.rootViewController = UINavigationController(rootViewController: MainViewController())
         self.window?.makeKeyAndVisible()
     }
 

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
@@ -62,7 +62,7 @@ final class ReportGraphViewController: UIViewController {
         reportGraphView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(reportTopView.snp.bottom)
-            $0.height.equalTo(290)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 290 : 242)
         }
         
         reportDescriptionView.snp.makeConstraints {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportLabelViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportLabelViewController.swift
@@ -59,15 +59,15 @@ final class ReportLabelViewController: UIViewController {
         }
         
         typeImageView.snp.makeConstraints {
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 20 : 15)
             $0.top.equalTo(reportTopView.snp.bottom)
-            $0.height.equalTo(290)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 290 : 242)
         }
         
         reportDescriptionView.snp.makeConstraints {
             $0.top.equalTo(typeImageView.snp.bottom)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(157)
+            $0.height.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 87 : 62)
         }
     }
     

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportOnePageViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportOnePageViewController.swift
@@ -57,8 +57,8 @@ final class ReportOnePageViewController: UIViewController {
         
         reportOnePageView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
-            $0.top.equalTo(monthButton.snp.bottom).offset(26)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(54)
+            $0.top.equalTo(monthButton.snp.bottom).offset(UIScreen.main.hasNotch ? 27 : 22)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 54 : 65)
         }
     }
     

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportRankingViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportRankingViewController.swift
@@ -58,13 +58,13 @@ final class ReportRankingViewController: UIViewController {
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(146)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 146 : 142)
         }
         
         reportRankingView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(reportTopView.snp.bottom)
-            $0.height.equalTo(290)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 290 : 242)
         }
         
         reportDescriptionView.snp.makeConstraints {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportSentenceViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportSentenceViewController.swift
@@ -50,13 +50,13 @@ final class ReportSentenceViewController: UIViewController {
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(146)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 146 : 142)
         }
         
         reportSentenceView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(reportTopView.snp.bottom)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(54)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 54 : 62)
         }
     }
     

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportViewController.swift
@@ -90,7 +90,7 @@ final class ReportViewController: UIPageViewController {
         
         naviBar.snp.makeConstraints {
             $0.leading.trailing.top.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(44)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 44 : 50)
         }
         
         downLoadButton.snp.makeConstraints {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportViewController.swift
@@ -27,9 +27,8 @@ final class ReportViewController: UIPageViewController {
     
     private let paginationStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.alignment = .center
-        $0.spacing = 15
-        $0.distribution = .fillEqually
+        $0.spacing = 13
+        $0.distribution = .equalSpacing
     }
     
     private let pageImageView1 = UIImageView().then {
@@ -100,17 +99,17 @@ final class ReportViewController: UIPageViewController {
             $0.width.height.equalTo(44)
         }
         
-        paginationStackView.snp.makeConstraints {
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(145)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(17)
-            $0.height.equalTo(6)
-        }
-        
         paginationStackView.addArrangedSubviews([pageImageView1,
                                                  pageImageView2,
                                                  pageImageView3,
                                                  pageImageView4,
                                                  pageImageView5])
+        
+        paginationStackView.snp.makeConstraints {
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(145)
+            $0.height.equalTo(6)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 18 : 26)
+        }
     }
     
     private func setupControllers() {
@@ -125,14 +124,17 @@ final class ReportViewController: UIPageViewController {
     }
     
     private func calculateHeight() {
-        let maxCount = dumyData.max()
-        page2.reportGraphView.maxCount = maxCount!
+        guard let maxCount = dumyData.max() else { return }
+        page2.reportGraphView.maxCount = maxCount
+        page5.reportOnePageView.maxCount = maxCount
         
         let midCount = dumyData.sorted(by: >)[2]
         page2.reportGraphView.midCount = midCount
+        page5.reportOnePageView.midCount = midCount
         
         for data in dumyData {
-            let height = 150 * data / maxCount!
+            let totalHeight = UIScreen.main.hasNotch ? 150 : 130
+            let height = totalHeight * data / maxCount
             heights.append(Double(height))
         }
     }

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/BarView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/BarView.swift
@@ -73,7 +73,7 @@ class BarView: UIView {
         barBackgroundView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.width.equalTo(4)
-            $0.height.equalTo(150)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 150 : 130)
             $0.top.equalToSuperview()
         }
         

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportDescriptionView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportDescriptionView.swift
@@ -64,8 +64,8 @@ class ReportDescriptionView: UIView {
         addSubviews([descriptionTitleLabel, descriptionContentLabel])
         
         descriptionTitleLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(20)
-            $0.top.equalToSuperview().inset(26)
+            $0.leading.equalToSuperview().inset(21)
+            $0.top.equalToSuperview().inset(25)
         }
         
         descriptionContentLabel.snp.makeConstraints {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportGraphView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportGraphView.swift
@@ -143,7 +143,7 @@ class ReportGraphView: UIView {
         
         monthLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(25)
-            $0.top.equalToSuperview().inset(31)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 31 : 21)
         }
         
         threeMonthButton.snp.makeConstraints {
@@ -157,12 +157,12 @@ class ReportGraphView: UIView {
         }
         
         maxCountLabel.snp.makeConstraints {
-            $0.top.equalTo(monthLabel.snp.bottom).offset(36)
+            $0.top.equalTo(monthLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 36 : 26)
             $0.leading.equalToSuperview().inset(25)
         }
         
         midCountLabel.snp.makeConstraints {
-            $0.top.equalTo(maxCountLabel.snp.bottom).offset(64)
+            $0.top.equalTo(maxCountLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 64 : 55)
             $0.leading.equalTo(maxCountLabel.snp.leading)
         }
         
@@ -174,7 +174,7 @@ class ReportGraphView: UIView {
         }
         
         minCountLabel.snp.makeConstraints {
-            $0.top.equalTo(midCountLabel.snp.bottom).offset(65)
+            $0.top.equalTo(midCountLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 65 : 55)
             $0.leading.equalTo(maxCountLabel.snp.leading)
         }
         
@@ -188,14 +188,14 @@ class ReportGraphView: UIView {
         [barView1, barView2, barView3, barView4, barView5].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalTo(28)
-                $0.height.equalTo(177)
+                $0.height.equalTo(UIScreen.main.hasNotch ? 177 : 157)
             }
         }
         
         barStackView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().inset(86)
-            $0.bottom.equalToSuperview().inset(27)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 86 : 67)
+            $0.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 27 : 18)
         }
     }
     

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportOnePageView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportOnePageView.swift
@@ -36,10 +36,26 @@ class ReportOnePageView: UIView {
     }
     
     private var sentenceView = UIView()
-    private var sentenceCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
+    private lazy var sentenceCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
         ReportSentenceCollectionViewCell.register(target: $0)
         $0.backgroundColor = Asset.Colors.black200.color
         $0.isScrollEnabled = false
+    }
+    
+    private var maxCountLabel = UILabel().then {
+        $0.textColor = Asset.Colors.white.color
+        $0.font = BDSFont.enBody8
+    }
+    
+    private var midCountLabel = UILabel().then {
+        $0.textColor = Asset.Colors.white.color
+        $0.font = BDSFont.enBody8
+    }
+    
+    private var minCountLabel = UILabel().then {
+        $0.text = "0"
+        $0.textColor = Asset.Colors.white.color
+        $0.font = BDSFont.enBody8
     }
     
     private var midLineView = UIView().then {
@@ -84,6 +100,18 @@ class ReportOnePageView: UIView {
     private var thirdRankingCountLabel = UILabel().then {
         $0.textColor = Asset.Colors.white.color
         $0.font = BDSFont.enBody3
+    }
+    
+    var maxCount: Int = 0 {
+        didSet {
+            maxCountLabel.text = "\(maxCount)"
+        }
+    }
+    
+    var midCount: Int = 0 {
+        didSet {
+            midCountLabel.text = "\(midCount)"
+        }
     }
     
     var firstRankingMedia: String = "" {
@@ -166,42 +194,59 @@ class ReportOnePageView: UIView {
         
         graphView.snp.makeConstraints {
             $0.width.equalToSuperview()
-            $0.height.equalTo(244)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 244 : 209)
         }
         
-        graphView.addSubviews([midLineView, minLineView, barStackView])
+        graphView.addSubviews([maxCountLabel, midCountLabel, minCountLabel, midLineView, minCountLabel, minLineView, barStackView])
         
         barStackView.addArrangedSubviews([barView1, barView2, barView3, barView4, barView5])
 
         [barView1, barView2, barView3, barView4, barView5].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalTo(28)
-                $0.height.equalTo(177)
+                $0.height.equalTo(UIScreen.main.hasNotch ? 177 : 157)
             }
         }
 
         barStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(53)
             $0.trailing.equalToSuperview().inset(54)
-            $0.top.equalToSuperview().inset(41)
-            $0.bottom.equalToSuperview().inset(26)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 41 : 28)
+            $0.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 26 : 19)
+        }
+        
+        maxCountLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(UIScreen.main.hasNotch ? 25 : 35)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 37 : 28)
+        }
+        
+        midCountLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(UIScreen.main.hasNotch ? 25 : 35)
+            $0.top.equalTo(maxCountLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 64 : 55)
         }
         
         midLineView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(117)
-            $0.leading.trailing.equalToSuperview().inset(44)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 116 : 98)
+            $0.leading.equalTo(midCountLabel.snp.trailing).offset(7)
+            $0.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 45 : 35)
             $0.height.equalTo(0.5)
         }
         
+        minCountLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(UIScreen.main.hasNotch ? 25 : 35)
+            $0.top.equalTo(midCountLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 64 : 55)
+        }
+        
         minLineView.snp.makeConstraints {
-            $0.top.equalTo(midLineView.snp.bottom).offset(74)
-            $0.leading.trailing.equalToSuperview().inset(44)
+            $0.top.equalTo(midLineView.snp.bottom).offset(UIScreen.main.hasNotch ? 75 : 65)
+            $0.leading.equalTo(midCountLabel.snp.trailing).offset(11)
+            $0.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 45 : 35)
             $0.height.equalTo(0.5)
         }
         
         reportOnePageHorizontalStackView2.snp.makeConstraints {
             $0.width.equalToSuperview()
-            $0.height.equalTo(130)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 130 : 123)
         }
         
         reportOnePageHorizontalStackView1.addArrangedSubviews([mediaImageView, sentenceView])
@@ -219,8 +264,8 @@ class ReportOnePageView: UIView {
         sentenceView.addSubview(sentenceCollectionView)
         
         sentenceCollectionView.snp.makeConstraints { 
-            $0.leading.trailing.equalToSuperview().inset(14)
-            $0.top.bottom.equalToSuperview().inset(32)
+            $0.leading.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 14 : 12)
+            $0.top.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 32 : 19)
         }
 
         secondRankingView.snp.makeConstraints {
@@ -306,10 +351,10 @@ class ReportOnePageView: UIView {
 
 extension ReportOnePageView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: calculateCellWidth(text: sentence[indexPath.item]), height: (collectionView.frame.height - 14*2)/3)
+        return CGSize(width: calculateCellWidth(text: sentence[indexPath.item]), height: 25)
     }
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 14
+        return UIScreen.main.hasNotch ? 14 : 8
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportOnePageView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportOnePageView.swift
@@ -204,7 +204,6 @@ class ReportOnePageView: UIView {
         [barView1, barView2, barView3, barView4, barView5].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalTo(28)
-                $0.height.equalTo(UIScreen.main.hasNotch ? 177 : 157)
             }
         }
 
@@ -257,15 +256,16 @@ class ReportOnePageView: UIView {
         }
 
         sentenceView.snp.makeConstraints {
-            $0.width.equalTo(138)
+            $0.width.equalTo(UIScreen.main.hasNotch ? 138 : 130)
             $0.top.bottom.equalToSuperview()
         }
         
         sentenceView.addSubview(sentenceCollectionView)
         
         sentenceCollectionView.snp.makeConstraints { 
-            $0.leading.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 14 : 12)
-            $0.top.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 32 : 19)
+            $0.width.equalTo(110)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 107 : 91)
+            $0.centerX.centerY.equalToSuperview()
         }
 
         secondRankingView.snp.makeConstraints {
@@ -287,7 +287,7 @@ class ReportOnePageView: UIView {
         thirdRankingView.addSubviews([thirdRankingMediaLabel, thirdRankingCountLabel])
         
         firstRankingCountLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(32)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 32 : 29)
             $0.centerX.equalToSuperview()
         }
         
@@ -297,7 +297,7 @@ class ReportOnePageView: UIView {
         }
         
         secondRankingCountLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(38)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 38 : 34)
             $0.centerX.equalToSuperview()
         }
         
@@ -307,7 +307,7 @@ class ReportOnePageView: UIView {
         }
         
         thirdRankingCountLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(38)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 38 : 34)
             $0.centerX.equalToSuperview()
         }
         

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportRankingView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportRankingView.swift
@@ -108,7 +108,7 @@ final class ReportRankingView: UIView {
         
         secondRankingView.snp.makeConstraints {
             $0.leading.bottom.equalToSuperview()
-            $0.height.equalTo(256)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 34 : 28)
             $0.width.equalTo(100)
         }
         
@@ -140,7 +140,7 @@ final class ReportRankingView: UIView {
         
         starImageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(firstRankingTypeLabel.snp.bottom).offset(86)
+            $0.top.equalTo(firstRankingTypeLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 86 : 48)
             $0.width.height.equalTo(18)
         }
         
@@ -151,7 +151,7 @@ final class ReportRankingView: UIView {
         
         thirdRankingView.snp.makeConstraints {
             $0.leading.equalTo(firstRankingView.snp.trailing).offset(2)
-            $0.height.equalTo(230)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 60 : 50)
             $0.trailing.bottom.equalToSuperview()
         }
         

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportSentenceView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportSentenceView.swift
@@ -213,14 +213,14 @@ class ReportSentenceView: UIView {
         [movieImageView, bookImageView, tvImageView, musicImageView, webtoonImageView, youtubeImageView].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalTo(165)
-                $0.height.equalTo(158)
+                $0.height.equalTo(UIScreen.main.hasNotch ? 158 : 131)
             }
         }
         
         [mediaHorizontalStackView1, mediaHorizontalStackView2, mediaHorizontalStackView3].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalToSuperview()
-                $0.height.equalTo(158)
+                $0.height.equalTo(UIScreen.main.hasNotch ? 158 : 131)
             }
         }
         
@@ -239,8 +239,8 @@ class ReportSentenceView: UIView {
         
         [movieCollectionView, bookCollectionView, tvCollectionView, musicCollectionView, webtoonCollectionView, youtubeCollectionView].forEach {
             $0.snp.makeConstraints {
-                $0.width.equalTo(120)
-                $0.height.equalTo(103)
+                $0.width.equalTo(UIScreen.main.hasNotch ? 110 : 98)
+                $0.height.equalTo(UIScreen.main.hasNotch ? 103 : 93)
                 $0.centerX.centerY.equalToSuperview()
             }
         }
@@ -340,7 +340,7 @@ extension ReportSentenceView: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 14
+        return UIScreen.main.hasNotch ? 14 : 9
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportSentenceView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportSentenceView.swift
@@ -213,14 +213,12 @@ class ReportSentenceView: UIView {
         [movieImageView, bookImageView, tvImageView, musicImageView, webtoonImageView, youtubeImageView].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalTo(165)
-                $0.height.equalTo(UIScreen.main.hasNotch ? 158 : 131)
             }
         }
         
         [mediaHorizontalStackView1, mediaHorizontalStackView2, mediaHorizontalStackView3].forEach {
             $0.snp.makeConstraints {
                 $0.width.equalToSuperview()
-                $0.height.equalTo(UIScreen.main.hasNotch ? 158 : 131)
             }
         }
         
@@ -239,7 +237,7 @@ class ReportSentenceView: UIView {
         
         [movieCollectionView, bookCollectionView, tvCollectionView, musicCollectionView, webtoonCollectionView, youtubeCollectionView].forEach {
             $0.snp.makeConstraints {
-                $0.width.equalTo(UIScreen.main.hasNotch ? 110 : 98)
+                $0.width.equalTo(UIScreen.main.hasNotch ? 120 : 115)
                 $0.height.equalTo(UIScreen.main.hasNotch ? 103 : 93)
                 $0.centerX.centerY.equalToSuperview()
             }

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportTopView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportTopView.swift
@@ -83,7 +83,7 @@ class ReportTopView: UIView {
         addSubviews([monthButton, starImageView, reportTitleLabel, reportDescriptionLabel])
         
         monthButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(23)
+            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 23 : 13)
             $0.leading.trailing.equalToSuperview().inset(133)
             $0.height.equalTo(31)
         }


### PR DESCRIPTION
### 관련 이슈
#28 

### 구현/변경 사항 및 이유
통계뷰에 대해서 아이폰13미니, 아이폰13프로, 아이폰se2 화면에서의 기기대응을 구현

### PR Point
노치의 여부에 따라서 se2화면과 아이폰13프로의 레이아웃을 분기처리했습니다.

