### PR TITLE
[Hotfix] 통계뷰 날짜 선택 버튼 수정 (#54)

### DIFF
--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
@@ -30,7 +30,6 @@ final class ReportGraphViewController: UIViewController {
         super.viewDidLoad()
         configUI()
         setupLayout()
-        bind()
     }
     
     // MARK: - InitUI
@@ -70,27 +69,11 @@ final class ReportGraphViewController: UIViewController {
     
     // MARK: - Custom Method
     
-    private func bind() {
-        reportGraphView.barView1.barTitle = addOrSubtractMonth(month: -5)
-        reportGraphView.barView2.barTitle = addOrSubtractMonth(month: -4)
-        reportGraphView.barView3.barTitle = addOrSubtractMonth(month: -3)
-        reportGraphView.barView4.barTitle = addOrSubtractMonth(month: -2)
-        reportGraphView.barView5.barTitle = addOrSubtractMonth(month: -1)
-    }
-    
     private func addOrSubtractMonth(month:Int) -> String {
         guard let date = Calendar.current.date(byAdding: .month, value: month, to: Date()) else { return "" }
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M월"
         return dateFormatter.string(from: date)
-    }
-    
-    private func setBarTitle(monts: [String]) {
-        reportGraphView.barView1.barTitle = monts[0]
-        reportGraphView.barView2.barTitle = monts[1]
-        reportGraphView.barView3.barTitle = monts[2]
-        reportGraphView.barView4.barTitle = monts[3]
-        reportGraphView.barView5.barTitle = monts[4]
     }
 }
 

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportGraphViewController.swift
@@ -36,9 +36,6 @@ final class ReportGraphViewController: UIViewController {
     // MARK: - InitUI
     
     private func configUI() {
-        reportTopView.monthButton.inputAccessoryView = setupToolbar()
-        reportTopView.monthButton.inputView = monthPicker
-        
         reportTopView.reportTitle = "월별 그래프"
         reportTopView.reportDescription = "가장 많은 기록을 한 달을 확인해보세요"
         
@@ -46,9 +43,7 @@ final class ReportGraphViewController: UIViewController {
         reportGraphView.threeMonthSelected = false
         reportGraphView.fiveMonthSelected = true
         
-        let calendar = Calendar.current
-        let month = calendar.component(.month, from: Date())
-        reportGraphView.month = String(month)
+        reportGraphView.month = addOrSubtractMonth(month: -1)
     }
     
     private func setupLayout() {
@@ -56,8 +51,8 @@ final class ReportGraphViewController: UIViewController {
         
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(146)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 126 : 115)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 70 : 66)
         }
         
         reportGraphView.snp.makeConstraints {
@@ -76,27 +71,11 @@ final class ReportGraphViewController: UIViewController {
     // MARK: - Custom Method
     
     private func bind() {
-        reportTopView.delegate = self
-        
         reportGraphView.barView1.barTitle = addOrSubtractMonth(month: -5)
         reportGraphView.barView2.barTitle = addOrSubtractMonth(month: -4)
         reportGraphView.barView3.barTitle = addOrSubtractMonth(month: -3)
         reportGraphView.barView4.barTitle = addOrSubtractMonth(month: -2)
         reportGraphView.barView5.barTitle = addOrSubtractMonth(month: -1)
-    }
-    
-    private func setupToolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        toolbar.backgroundColor = Asset.Colors.white.color
-        toolbar.tintColor = Asset.Colors.black200.color
-        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 45)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(touchupDoneButton))
-        toolbar.setItems([flexibleSpace, doneButton], animated: true)
-        
-        return toolbar
     }
     
     private func addOrSubtractMonth(month:Int) -> String {
@@ -113,30 +92,6 @@ final class ReportGraphViewController: UIViewController {
         reportGraphView.barView4.barTitle = monts[3]
         reportGraphView.barView5.barTitle = monts[4]
     }
-    
-    // MARK: - @objc
-    
-    @objc func touchupDoneButton() {
-        reportTopView.monthButton.setTitle("\(monthPicker.year)년 \(monthPicker.month)월", for: .normal)
-        view.endEditing(true)
-        
-        reportAPI.getSecondReport(date: "\(monthPicker.year)-\(monthPicker.month)", count: 5) { [weak self] data, err in
-            guard let self = self else { return }
-            guard let data = data else { return }
-            
-            self.reportDescriptionView.descriptionTitle = data.title
-            self.reportDescriptionView.descriptionContent = data.comment
-            
-            // MARK: - TODO : 통계 그래프 높이 계산
-            
-        }
-    }
-}
-
-// MARK: - ReportTopView Delegate
-
-extension ReportGraphViewController: ReportTopViewDelegate {
-    func touchupMonthButton() { }
 }
 
 // MARK: - ReportGraphView Delegate

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportLabelViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportLabelViewController.swift
@@ -18,7 +18,7 @@ final class ReportLabelViewController: UIViewController {
     
     // MARK: - Properties
     
-    private var reportTopView = ReportTopView()
+    var reportTopView = ReportTopView()
     var typeImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
     }
@@ -34,15 +34,11 @@ final class ReportLabelViewController: UIViewController {
         super.viewDidLoad()
         configUI()
         setupLayout()
-        bind()
     }
     
     // MARK: - InitUI
     
     private func configUI() {
-        reportTopView.monthButton.inputAccessoryView = setupToolbar()
-        reportTopView.monthButton.inputView = monthPicker
-        
         reportTopView.reportTitle = "\(addOrSubtractMonth(month: -1))의 밴토리님은?"
         reportTopView.reportDescription = "이번 달 나의 소비 유형을 알아보세요"
     }
@@ -52,8 +48,8 @@ final class ReportLabelViewController: UIViewController {
         
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(UIScreen.main.hasNotch ? 146 : 142)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 126 : 115)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 70 : 66)
         }
         
         typeImageView.snp.makeConstraints {
@@ -69,25 +65,7 @@ final class ReportLabelViewController: UIViewController {
         }
     }
     
-    private func bind() {
-        reportTopView.delegate = self
-    }
-    
     // MARK: - Custom Method
-
-    private func setupToolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        toolbar.backgroundColor = .white
-        toolbar.tintColor = Asset.Colors.black200.color
-        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 45)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(touchupDoneButton))
-        toolbar.setItems([flexibleSpace, doneButton], animated: true)
-        
-        return toolbar
-    }
     
     private func addOrSubtractMonth(month:Int) -> String {
         guard let date = Calendar.current.date(byAdding: .month, value: month, to: Date()) else { return "" }
@@ -95,30 +73,4 @@ final class ReportLabelViewController: UIViewController {
         dateFormatter.dateFormat = "M월"
         return dateFormatter.string(from: date)
     }
-    
-    // MARK: - @objc
-    
-    @objc func touchupDoneButton() {
-        reportTopView.monthButton.setTitle("\(monthPicker.year)년 \(monthPicker.month)월", for: .normal)
-        view.endEditing(true)
-        
-        reportAPI.getFirstReport(date: "\(monthPicker.year)-\(monthPicker.month)") { [weak self] data, err in
-            guard let self = self else { return }
-            guard let data = data else { return }
-            
-            self.reportDescriptionView.descriptionTitle = data.title
-            self.reportDescriptionView.descriptionContent = data.comment
-            
-            let listURL = URL(string: data.poster)
-            self.typeImageView.kf.setImage(with: listURL)
-            
-            self.reportTopView.reportTitle = "\(self.monthPicker.month)월의 밴토리님은?"
-        }
-    }
-}
-
-// MARK: - ReportTopView Delegate
-
-extension ReportLabelViewController: ReportTopViewDelegate {
-    func touchupMonthButton() { }
 }

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportOnePageViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportOnePageViewController.swift
@@ -14,11 +14,6 @@ final class ReportOnePageViewController: UIViewController {
 
     // MARK: - Properties
     
-    private var monthButton = RespondingButton().then {
-        $0.setTitleColor(Asset.Colors.black200.color, for: .normal)
-        $0.titleLabel?.font = BDSFont.enBody7
-    }
-    
     var reportOnePageView = ReportOnePageView()
     private var monthPicker = MonthYearPickerView()
     
@@ -35,60 +30,16 @@ final class ReportOnePageViewController: UIViewController {
     // MARK: - InitUI
     
     private func configUI() {
-        monthButton.inputAccessoryView = setupToolbar()
-        monthButton.inputView = monthPicker
-        
-        monthButton.layer.borderWidth = 1
-        monthButton.layer.borderColor = Asset.Colors.gray200.color.cgColor
-        monthButton.makeRound(radius: 31 / 2)
-        
-        let month = addOrSubtractMonth(month: -1)
-        monthButton.setTitle("\(month)", for: .normal)
+        view.backgroundColor = Asset.Colors.white.color
     }
     
     private func setupLayout() {
-        view.addSubviews([monthButton, reportOnePageView])
-        
-        monthButton.snp.makeConstraints {
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(132)
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(73)
-            $0.height.equalTo(31)
-        }
+        view.addSubviews([reportOnePageView])
         
         reportOnePageView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
-            $0.top.equalTo(monthButton.snp.bottom).offset(UIScreen.main.hasNotch ? 27 : 22)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 126 : 115)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 54 : 65)
         }
-    }
-    
-    // MARK: - Custom Method
-    
-    private func setupToolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        toolbar.backgroundColor = Asset.Colors.white.color
-        toolbar.tintColor = Asset.Colors.black200.color
-        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 45)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(touchupDoneButton))
-        toolbar.setItems([flexibleSpace, doneButton], animated: true)
-        
-        return toolbar
-    }
-    
-    private func addOrSubtractMonth(month:Int) -> String {
-        guard let date = Calendar.current.date(byAdding: .month, value: month, to: Date()) else { return "" }
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "YYYY년 MM월"
-        return dateFormatter.string(from: date)
-    }
-    
-    // MARK: - @objc
-    
-    @objc func touchupDoneButton() {
-        monthButton.setTitle("\(monthPicker.year)년 \(monthPicker.month)월", for: .normal)
-        view.endEditing(true)
     }
 }

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportRankingViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportRankingViewController.swift
@@ -36,9 +36,6 @@ final class ReportRankingViewController: UIViewController {
     // MARK: - InitUI
     
     private func configUI() {
-        reportTopView.monthButton.inputAccessoryView = setupToolbar()
-        reportTopView.monthButton.inputView = monthPicker
-        
         reportTopView.reportTitle = "유형별 랭킹"
         reportTopView.reportDescription = "\(addOrSubtractMonth(month: -1)) 한 달 기록률이 가장 높은 top 3"
     }
@@ -48,8 +45,8 @@ final class ReportRankingViewController: UIViewController {
         
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(UIScreen.main.hasNotch ? 146 : 142)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 126 : 115)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 70 : 66)
         }
         
         reportRankingView.snp.makeConstraints {
@@ -67,61 +64,11 @@ final class ReportRankingViewController: UIViewController {
     
     // MARK: - Custom Method
     
-    private func bind() {
-        reportTopView.delegate = self
-    }
-    
-    private func setupToolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        toolbar.backgroundColor = Asset.Colors.white.color
-        toolbar.tintColor = Asset.Colors.black200.color
-        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 45)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(touchupDoneButton))
-        toolbar.setItems([flexibleSpace, doneButton], animated: true)
-        
-        return toolbar
-    }
-    
     private func addOrSubtractMonth(month:Int) -> String {
         guard let date = Calendar.current.date(byAdding: .month, value: month, to: Date()) else { return "" }
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M월"
         return dateFormatter.string(from: date)
     }
-    
-    // MARK: - @objc
-
-    @objc func touchupDoneButton() {
-        reportTopView.monthButton.setTitle("\(monthPicker.year)년 \(monthPicker.month)월", for: .normal)
-        view.endEditing(true)
-        
-        // MARK: - TODO: 01~09월의 데이터 통신 
-        
-        reportAPI.getThirdReport(date: "\(monthPicker.year)-\(monthPicker.month)") { [weak self] data, err in
-            guard let self = self else { return }
-            guard let data = data else { return }
-            
-            self.reportTopView.reportDescription = "\(self.monthPicker.month)월 한 달 기록률이 가장 높은 top3"
-            
-            self.reportRankingView.firstType = data.arr[0].type
-            self.reportRankingView.firstCount = data.arr[0].count
-            self.reportRankingView.secondType = data.arr[1].type
-            self.reportRankingView.secondCount = data.arr[1].count
-            self.reportRankingView.thirdType = data.arr[2].type
-            self.reportRankingView.thirdCount = data.arr[2].count
-            
-            self.reportDescriptionView.descriptionTitle = data.title
-            self.reportDescriptionView.descriptionContent = data.label
-        }
-    }
-}
-
-// MARK: - ReportTopView Delegate
-
-extension ReportRankingViewController: ReportTopViewDelegate {
-    func touchupMonthButton() { }
 }
 

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportSentenceViewController.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Controllers/ReportSentenceViewController.swift
@@ -43,9 +43,6 @@ final class ReportSentenceViewController: UIViewController {
     // MARK: - InitUI
     
     private func configUI() {
-        reportTopView.monthButton.inputAccessoryView = setupToolbar()
-        reportTopView.monthButton.inputView = monthPicker
-        
         reportTopView.reportTitle = "유형별 한 줄 리뷰 순위"
         reportTopView.reportDescription = "유형 카드를 탭하여 확인해보세요"
     }
@@ -55,8 +52,8 @@ final class ReportSentenceViewController: UIViewController {
         
         reportTopView.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(44)
-            $0.height.equalTo(UIScreen.main.hasNotch ? 146 : 142)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.hasNotch ? 126 : 115)
+            $0.height.equalTo(UIScreen.main.hasNotch ? 70 : 66)
         }
         
         reportSentenceView.snp.makeConstraints {
@@ -69,7 +66,6 @@ final class ReportSentenceViewController: UIViewController {
     // MARK: - Custom Method
     
     private func bind() {
-        reportTopView.delegate = self
         reportSentenceView.delegate = self
         
         reportSentenceView.movieData = movieData
@@ -78,50 +74,6 @@ final class ReportSentenceViewController: UIViewController {
         reportSentenceView.musicData = musicData
         reportSentenceView.webtoonData = webtoonData
         reportSentenceView.youtubeData = youtubeData
-    }
-    
-    private func setupToolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        toolbar.backgroundColor = Asset.Colors.white.color
-        toolbar.tintColor = Asset.Colors.black200.color
-        toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 45)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(touchupDoneButton))
-        toolbar.setItems([flexibleSpace, doneButton], animated: true)
-        
-        return toolbar
-    }
-    
-    // MARK: - @objc
-
-    @objc func touchupDoneButton() {
-        reportTopView.monthButton.setTitle("\(monthPicker.year)년 \(monthPicker.month)월", for: .normal)
-        view.endEditing(true)
-        
-        reportAPI.getFourthReport(date: "\(monthPicker.year)-\(monthPicker.month)") { [weak self] data, err in
-            guard let self = self else { return }
-            guard let data = data else { return }
-            
-            // MARK: - TODO : 데이터 초기화 및 리로드
-
-            self.musicData.removeAll()
-            self.bookData.removeAll()
-            self.tvData.removeAll()
-            self.musicData.removeAll()
-            self.webtoonData.removeAll()
-            self.youtubeData.removeAll()
-            
-            self.movieData = data.oneline.movie
-            self.bookData = data.oneline.book
-            self.tvData = data.oneline.tv
-            self.musicData = data.oneline.music
-            self.webtoonData = data.oneline.webtoon
-            self.youtubeData = data.oneline.youtube
-            
-            self.reportSentenceView.reloadCollectionView()
-        }
     }
 }
 
@@ -181,10 +133,4 @@ extension ReportSentenceViewController: ReportSentenceViewDelegate {
         }
         UIView.transition(with: reportSentenceView.youtubeImageView, duration: 0.3, options: .transitionFlipFromLeft, animations: nil, completion: nil)
     }
-}
-
-// MARK: - ReportTopView Delegate
-
-extension ReportSentenceViewController: ReportTopViewDelegate {
-    func touchupMonthButton() { }
 }

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportGraphView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportGraphView.swift
@@ -80,7 +80,7 @@ class ReportGraphView: UIView {
     
     var month: String = "" {
         didSet {
-            monthLabel.text = "\(month)월"
+            monthLabel.text = "\(month)"
         }
     }
     

--- a/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportTopView.swift
+++ b/Beforeget-iOS/Beforeget-iOS/Source/Screen/Report/Views/ReportTopView.swift
@@ -10,21 +10,9 @@ import UIKit
 import SnapKit
 import Then
 
-// MARK: - Protocol
-
-protocol ReportTopViewDelegate: AnyObject {
-    func touchupMonthButton()
-}
-
 class ReportTopView: UIView {
 
     // MARK: - Properties
-    
-    var monthButton = RespondingButton().then {
-        $0.setTitleColor(Asset.Colors.black200.color, for: .normal)
-        $0.addTarget(self, action: #selector(touchupMonthButton), for: .touchUpInside)
-        $0.titleLabel?.font = BDSFont.enBody7
-    }
     
     private var starImageView = UIImageView().then {
         $0.image = Asset.Assets.icnStarBlack.image
@@ -53,8 +41,6 @@ class ReportTopView: UIView {
         }
     }
     
-    weak var delegate: ReportTopViewDelegate?
-    
     // MARK: - Initializer
     
     init() {
@@ -71,27 +57,14 @@ class ReportTopView: UIView {
     // MARK: - InitUI
     
     private func configUI() {
-        backgroundColor = .white
-        
-        monthButton.layer.borderWidth = 1
-        monthButton.layer.borderColor = Asset.Colors.gray200.color.cgColor
-        monthButton.makeRound(radius: 31 / 2)
-        
-        let month = addOrSubtractMonth(month: -1)
-        monthButton.setTitle("\(month)", for: .normal)
+        backgroundColor = Asset.Colors.white.color
     }
     
     private func setupLayout() {
-        addSubviews([monthButton, starImageView, reportTitleLabel, reportDescriptionLabel])
-        
-        monthButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 23 : 13)
-            $0.leading.trailing.equalToSuperview().inset(133)
-            $0.height.equalTo(31)
-        }
+        addSubviews([starImageView, reportTitleLabel, reportDescriptionLabel])
         
         starImageView.snp.makeConstraints {
-            $0.top.equalTo(monthButton.snp.bottom).offset(27)
+            $0.top.equalToSuperview().inset(3)
             $0.leading.equalToSuperview().inset(20)
             $0.width.height.equalTo(18)
         }
@@ -105,19 +78,5 @@ class ReportTopView: UIView {
             $0.leading.equalToSuperview().inset(20)
             $0.top.equalTo(reportTitleLabel.snp.bottom).offset(7)
         }
-    }
-    
-    private func addOrSubtractMonth(month:Int) -> String {
-        guard let date = Calendar.current.date(byAdding: .month, value: month, to: Date()) else { return "" }
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "YYYY년 MM월"
-        return dateFormatter.string(from: date)
-    }
-    
-    // MARK: - @objc
-    
-    @objc func touchupMonthButton() {
-        monthButton.becomeFirstResponder()
-        delegate?.touchupMonthButton()
     }
 }


### PR DESCRIPTION
### 관련 이슈
#54 

### 구현/변경 사항 및 이유
통계뷰 버튼 레이아웃 및 버튼 로직 수정 

### PR Point
기존의 각 뷰에 있는 날짜 선택 버튼을 UIPageViewController로 빼서 고정된 위치로 만들어주었습니다. 
그에 따라 서버 통신도 현재 인덱스의 값에 따라서 다른 서버 API를 호출하도록 구현했습니다. 
